### PR TITLE
Add preferred side and bye functionality

### DIFF
--- a/src/components/americano/AddPlayers.vue
+++ b/src/components/americano/AddPlayers.vue
@@ -23,6 +23,14 @@
                             }"
                             required
                         />
+                        <select
+                            class="form-control mt-1"
+                            v-model="player.preferredSide"
+                        >
+                            <option value="Left">Left</option>
+                            <option value="Right">Right</option>
+                            <option value="Both">Both</option>
+                        </select>
                         <small
                             id="duplicateNameHelp"
                             class="form-text text-danger"

--- a/src/components/americano/ShowGames.vue
+++ b/src/components/americano/ShowGames.vue
@@ -20,6 +20,7 @@
                             class="game-container"
                         >
                             <div
+                                v-if="game.players.length === 4"
                                 class="d-flex flex-row justify-content-between"
                             >
                                 <div class="team-element p-2">
@@ -51,6 +52,11 @@
                                         @focusout="handleFocusChange(game, 2)"
                                     />
                                 </div>
+                            </div>
+                            <div v-else class="p-2">
+                                Oversidder: {{
+                                    getPlayerNameById(game.players[0].playerId)
+                                }}
                             </div>
                         </div>
                     </div>
@@ -150,6 +156,12 @@ export default defineComponent({
             if (this.isEven(index)) return this.getCourt(0) || "Bana 1";
 
             return this.getCourt(1) || "Bana 2";
+        },
+        getPlayerNameById(id: number) {
+            const player = store.getters.americanoStore.getPlayers.find(
+                (p: any) => p.id === id
+            );
+            return player ? player.name : "";
         },
     },
     computed: {

--- a/src/models/padelPlayer.interface.ts
+++ b/src/models/padelPlayer.interface.ts
@@ -1,5 +1,8 @@
+export type PreferredSide = "Left" | "Right" | "Both";
+
 export interface PadelPlayer {
     name: string;
     score: number;
     id: number;
+    preferredSide: PreferredSide;
 }

--- a/src/models/playerScore.interface.ts
+++ b/src/models/playerScore.interface.ts
@@ -1,4 +1,7 @@
+import { PreferredSide } from "./padelPlayer.interface";
+
 export interface PlayerScore {
     playerId: number;
     home: boolean;
+    side?: PreferredSide;
 }

--- a/src/services/htmlHelperService.ts
+++ b/src/services/htmlHelperService.ts
@@ -8,6 +8,17 @@ export function getFullPlayerNames(game: PadelGame, side: GameSide) {
 
     const players = game.players.filter(p => p.home === isHome);
 
+    if (players.length === 0) {
+        return "";
+    }
+
+    if (players.length === 1) {
+        const single = store.getters.americanoStore.getPlayers.find(
+            p => p.id === players[0].playerId
+        );
+        return single ? single.name : "";
+    }
+
     const firstPlayer = store.getters.americanoStore.getPlayers.find(
         p => p.id === players[0].playerId
     );


### PR DESCRIPTION
## Summary
- allow player side preference via new field
- generate random games and support byes if player count isn't 8 or 16
- store each player's side on matches
- show oversiddere in schedule
- expose side option when adding players

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_b_6888c0d3795c8332b485cb51b5761424