### PR TITLE
Support dynamic players and courts

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ The website is available [here](https://www.padelamericano.nu).
 # :heavy_check_mark: Features
 
 -   Create a schedule for Padel Americano
--   Choose between 8 and 16 players
--   Choose maximum points per round
+-   Choose between 4 and 16 players
+-   Choose maximum points per round (default is 24)
 -   Shuffle the schedule
 -   Color code the group split when using 16 players
 -   Automatically calculate the opponent's points

--- a/src/components/americano/AddPlayers.vue
+++ b/src/components/americano/AddPlayers.vue
@@ -57,8 +57,13 @@
                                 @change="handleAmountOfPlayersChange"
                                 :disabled="getIsGamePrepared"
                             >
-                                <option value="8">8</option>
-                                <option value="16">16</option>
+                                <option
+                                    v-for="n in playerOptions"
+                                    :key="n"
+                                    :value="n"
+                                >
+                                    {{ n }}
+                                </option>
                             </select>
                         </div>
                         <div class="form-group">
@@ -83,15 +88,13 @@
                             </small>
                         </div>
 
-                        <div
-                            class="form-group"
-                            v-if="amountOfPlayersRule === 8"
-                        >
+                        <div class="form-group">
                             <label for="courtNames" class="form-label"
                                 >Court names</label
                             >
-                            <div class="d-flex flex-row" id="courtNames">
+                            <div class="d-flex flex-row flex-wrap" id="courtNames">
                                 <input
+                                    v-if="numberOfCourts >= 1"
                                     type="text"
                                     class="form-control m-2"
                                     v-model="court1"
@@ -99,10 +102,27 @@
                                 />
 
                                 <input
+                                    v-if="numberOfCourts >= 2"
                                     type="text"
                                     class="form-control m-2"
                                     placeholder="Court 2"
                                     v-model="court2"
+                                />
+
+                                <input
+                                    v-if="numberOfCourts >= 3"
+                                    type="text"
+                                    class="form-control m-2"
+                                    placeholder="Court 3"
+                                    v-model="court3"
+                                />
+
+                                <input
+                                    v-if="numberOfCourts >= 4"
+                                    type="text"
+                                    class="form-control m-2"
+                                    placeholder="Court 4"
+                                    v-model="court4"
                                 />
                             </div>
 
@@ -193,7 +213,7 @@ import { defineComponent } from "vue";
 export default defineComponent({
     data: function() {
         return {
-            maxScore: 32,
+            maxScore: 24,
             maxScoreInvalid: false,
             duplicateNameIds: [] as number[],
         };
@@ -227,7 +247,7 @@ export default defineComponent({
             store.commit.americanoStore.RESET();
             this.$data.duplicateNameIds = [];
             this.$data.maxScoreInvalid = false;
-            this.$data.maxScore = 32;
+            this.$data.maxScore = 24;
         },
         onMaxScoreChange() {
             const value = this.$data.maxScore;
@@ -310,8 +330,7 @@ export default defineComponent({
                 return store.getters.americanoStore.getRules.amountOfPlayers;
             },
             set(amount: number) {
-                const colorCode =
-                    Number(amount) === 8 ? false : this.colorCodeRule;
+                const colorCode = Number(amount) === 16 ? this.colorCodeRule : false;
 
                 const newRules: PadelRules = {
                     ...store.getters.americanoStore.getRules,
@@ -352,6 +371,48 @@ export default defineComponent({
                 };
                 store.commit.americanoStore.SET_RULES(newRules);
             },
+        },
+        court3: {
+            get() {
+                const rules = store.getters.americanoStore.getRules;
+                if (rules.courtNames) return rules.courtNames[2];
+                return "";
+            },
+            set(name: string) {
+                const courts = store.getters.americanoStore.getRules.courtNames;
+                courts[2] = name;
+                const newRules: PadelRules = {
+                    ...store.getters.americanoStore.getRules,
+                    courtNames: courts,
+                };
+                store.commit.americanoStore.SET_RULES(newRules);
+            },
+        },
+        court4: {
+            get() {
+                const rules = store.getters.americanoStore.getRules;
+                if (rules.courtNames) return rules.courtNames[3];
+                return "";
+            },
+            set(name: string) {
+                const courts = store.getters.americanoStore.getRules.courtNames;
+                courts[3] = name;
+                const newRules: PadelRules = {
+                    ...store.getters.americanoStore.getRules,
+                    courtNames: courts,
+                };
+                store.commit.americanoStore.SET_RULES(newRules);
+            },
+        },
+        numberOfCourts() {
+            return Math.ceil(this.amountOfPlayersRule / 4);
+        },
+        playerOptions() {
+            const opts = [] as number[];
+            for (let i = 4; i <= 16; i++) {
+                opts.push(i);
+            }
+            return opts;
         },
         colorCodeRule: {
             get() {

--- a/src/components/americano/ShowGames.vue
+++ b/src/components/americano/ShowGames.vue
@@ -34,7 +34,7 @@
                                 </div>
 
                                 <span class="team-element pt-2">
-                                    {{ printCourt(index) }}</span
+                                    {{ printCourt(game, index) }}</span
                                 >
 
                                 <div class="team-element p-2 align-self-center">
@@ -142,20 +142,25 @@ export default defineComponent({
 
             return game.playGroup;
         },
-        isEven(index: number) {
-            return index % 2 == 0;
-        },
         getCourt(index: number) {
             const rules = this.getRules;
             if (rules.courtNames) return rules.courtNames[index];
             return "";
         },
-        printCourt(index: number) {
-            if (this.getRules.amountOfPlayers === 16) return "";
+        printCourt(game: PadelGame, index: number) {
+            const courts = Math.ceil(this.getRules.amountOfPlayers / 4);
 
-            if (this.isEven(index)) return this.getCourt(0) || "Bana 1";
+            let courtIndex = game.matchNumber - 1;
 
-            return this.getCourt(1) || "Bana 2";
+            if (this.getRules.amountOfPlayers === 16) {
+                courtIndex = (game.playGroup - 1) * 2 + (game.matchNumber - 1);
+            }
+
+            if (courtIndex < 0 || courtIndex >= courts) {
+                courtIndex = index % courts;
+            }
+
+            return this.getCourt(courtIndex) || `Bana ${courtIndex + 1}`;
         },
         getPlayerNameById(id: number) {
             const player = store.getters.americanoStore.getPlayers.find(

--- a/src/services/scoreService.ts
+++ b/src/services/scoreService.ts
@@ -4,7 +4,8 @@ import { PadelPlayer } from "@/models/padelPlayer.interface";
 
 export function updatePlayerScores(
     players: PadelPlayer[],
-    games: PadelGame[]
+    games: PadelGame[],
+    maxScore: number
 ): PadelPlayer[] {
     // reset score
     players.forEach(player => (player.score = 0));
@@ -16,6 +17,11 @@ export function updatePlayerScores(
             );
 
             if (!playerScore) {
+                return;
+            }
+
+            if (game.players.length === 1) {
+                player.score += Math.floor(maxScore / 2);
                 return;
             }
 

--- a/src/store/modules/americanoStore.ts
+++ b/src/store/modules/americanoStore.ts
@@ -48,11 +48,11 @@ export default {
         step: 1,
         isGamePrepared: false,
         rules: {
-            maxScore: 32,
+            maxScore: 24,
             randomSchedule: false,
             amountOfPlayers: 8,
             colorCode: false,
-            courtNames: ["", ""],
+            courtNames: ["", "", "", ""],
         },
     } as AmericanoStoreState,
     mutations: {
@@ -107,11 +107,11 @@ export default {
             state.games = [];
             state.step = 1;
             state.isGamePrepared = false;
-            state.rules.maxScore = 32;
+            state.rules.maxScore = 24;
             state.rules.randomSchedule = false;
             state.rules.amountOfPlayers = 8;
             state.rules.colorCode = false;
-            state.rules.courtNames = ["", ""];
+            state.rules.courtNames = ["", "", "", ""];
             removeAmericanoState();
         },
         LOAD_STATE(state: AmericanoStoreState) {
@@ -143,7 +143,8 @@ export default {
         updatePlayerScores({ commit, getters }: AmericanoStoreActions) {
             const updatedPlayers = updatePlayerScores(
                 getters.getPlayers,
-                getters.getGames
+                getters.getGames,
+                getters.getRules.maxScore
             );
             commit("UPDATE_PLAYERS", updatedPlayers);
         },


### PR DESCRIPTION
## Summary
- allow selecting 4‑16 players
- default max score is 24
- oversitters automatically get half the max score
- support naming up to four courts
- show courts in match view

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6888ce1252048332842fb07c6d82a08d