### PR TITLE
Add player seeding drag and drop

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The website is available [here](https://www.padelamericano.nu).
 -   Color code the group split when using 16 players
 -   Automatically calculate the opponent's points
 -   Enter match results to determine the winner
+-   Reorder players with drag and drop to set seeds in Mexicano mode
 
 # :clipboard: Technologies
 

--- a/src/components/americano/AddPlayers.vue
+++ b/src/components/americano/AddPlayers.vue
@@ -9,6 +9,10 @@
                         v-for="(player, index) in getPlayers"
                         :key="player.id"
                         class="form-group"
+                        draggable="true"
+                        @dragstart="onDragStart(index)"
+                        @dragover.prevent
+                        @drop="onDrop(index)"
                     >
                         <input
                             type="text"
@@ -237,6 +241,7 @@ export default defineComponent({
             maxScore: 24,
             maxScoreInvalid: false,
             duplicateNameIds: [] as number[],
+            dragIndex: null as number | null,
         };
     },
     methods: {
@@ -296,6 +301,20 @@ export default defineComponent({
         },
         isDuplicateName(id: number) {
             return this.$data.duplicateNameIds.includes(id);
+        },
+        onDragStart(index: number) {
+            this.$data.dragIndex = index;
+        },
+        onDrop(index: number) {
+            if (this.$data.dragIndex === null) {
+                return;
+            }
+            const players = [...this.getPlayers];
+            const moved = players.splice(this.$data.dragIndex, 1)[0];
+            players.splice(index, 0, moved);
+            players.forEach((p, i) => (p.seed = i + 1));
+            store.commit.americanoStore.UPDATE_PLAYERS(players);
+            this.$data.dragIndex = null;
         },
         getColorCodeGroup(player: PadelPlayer) {
             if (store.getters.americanoStore.getRules.colorCode === false) {
@@ -419,6 +438,16 @@ export default defineComponent({
         },
         getIsGamePrepared() {
             return store.getters.americanoStore.getIsGamePrepared;
+        },
+        playerOptions() {
+            const options: number[] = [];
+            for (let i = 4; i <= 16; i++) {
+                options.push(i);
+            }
+            return options;
+        },
+        numberOfCourts() {
+            return Math.ceil(this.amountOfPlayersRule / 4);
         },
     },
 });


### PR DESCRIPTION
## Summary
- enable drag-and-drop on player rows
- track dragged player index and update seeds on drop
- expose player count options and court count as computed values
- document drag and drop seeding in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_688923bc46c883329faee0c46178850a