### PR TITLE
Implement localstorage persistence

### DIFF
--- a/src/components/americano/AddPlayers.vue
+++ b/src/components/americano/AddPlayers.vue
@@ -294,6 +294,7 @@ export default defineComponent({
         },
         handlePlayerNameChange() {
             this.$data.duplicateNameIds = getDuplicateIds(this.getPlayers);
+            store.dispatch.americanoStore.saveStateManually();
         },
         handleAmountOfPlayersChange() {
             const players = getPadelPlayers(this.amountOfPlayersRule);
@@ -338,6 +339,20 @@ export default defineComponent({
     },
     created() {
         this.$data.maxScore = store.getters.americanoStore.getRules.maxScore;
+    },
+    watch: {
+        getPlayers: {
+            handler() {
+                store.dispatch.americanoStore.saveStateManually();
+            },
+            deep: true,
+        },
+        getRules: {
+            handler() {
+                store.dispatch.americanoStore.saveStateManually();
+            },
+            deep: true,
+        },
     },
     computed: {
         getPlayers() {

--- a/src/store/modules/americanoStore.ts
+++ b/src/store/modules/americanoStore.ts
@@ -129,6 +129,13 @@ export default {
         },
         SET_RULES(state: AmericanoStoreState, rules: PadelRules) {
             state.rules = rules;
+            saveAmericanoState(
+                state.players,
+                state.games,
+                state.step,
+                state.rules,
+                state.round
+            );
         },
         RESET(state: AmericanoStoreState) {
             state.players = getPadelPlayers();


### PR DESCRIPTION
## Summary
- persist rules to localStorage when changed
- watch player/rule changes so edits are saved immediately
- trigger a manual save when editing player names

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_688926a7b48883328f49a8c973850f61