### PR TITLE
Add drag-and-drop seeding list

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The website is available [here](https://www.padelamericano.nu).
 -   Color code the group split when using 16 players
 -   Automatically calculate the opponent's points
 -   Enter match results to determine the winner
--   Reorder players with drag and drop to set seeds in Mexicano mode
+-   Separate seeding list with drag and drop for Mexicano mode
 
 # :clipboard: Technologies
 

--- a/src/components/americano/AddPlayers.vue
+++ b/src/components/americano/AddPlayers.vue
@@ -9,10 +9,6 @@
                         v-for="(player, index) in getPlayers"
                         :key="player.id"
                         class="form-group"
-                        draggable="true"
-                        @dragstart="onDragStart(index)"
-                        @dragover.prevent
-                        @drop="onDrop(index)"
                     >
                         <input
                             type="text"
@@ -35,15 +31,6 @@
                             <option value="Right">Right</option>
                             <option value="Both">Both</option>
                         </select>
-                        <input
-                            v-if="modeRule === 'Mexicano'"
-                            type="number"
-                            class="form-control mt-1"
-                            v-model.number="player.seed"
-                            min="1"
-                            :max="getPlayers.length"
-                            placeholder="Seed"
-                        />
                         <small
                             id="duplicateNameHelp"
                             class="form-text text-danger"
@@ -211,6 +198,12 @@
                 </div>
             </div>
 
+            <div class="row mt-3" v-if="modeRule === 'Mexicano'">
+                <div class="col-12">
+                    <SeedPlayers />
+                </div>
+            </div>
+
             <div class="form-group">
                 <button type="button" @click="reset" class="btn btn-pdl mr-3">
                     <i class="las la-times"></i> Start over
@@ -234,14 +227,15 @@ import {
 import { getDuplicateIds, isValidMaxScore } from "@/services/htmlHelperService";
 import store from "@/store/index";
 import { defineComponent } from "vue";
+import SeedPlayers from "@/components/americano/SeedPlayers.vue";
 
 export default defineComponent({
+    components: { SeedPlayers },
     data: function() {
         return {
             maxScore: 24,
             maxScoreInvalid: false,
             duplicateNameIds: [] as number[],
-            dragIndex: null as number | null,
         };
     },
     methods: {
@@ -302,20 +296,6 @@ export default defineComponent({
         },
         isDuplicateName(id: number) {
             return this.$data.duplicateNameIds.includes(id);
-        },
-        onDragStart(index: number) {
-            this.$data.dragIndex = index;
-        },
-        onDrop(index: number) {
-            if (this.$data.dragIndex === null) {
-                return;
-            }
-            const players = [...this.getPlayers];
-            const moved = players.splice(this.$data.dragIndex, 1)[0];
-            players.splice(index, 0, moved);
-            players.forEach((p, i) => (p.seed = i + 1));
-            store.commit.americanoStore.UPDATE_PLAYERS(players);
-            this.$data.dragIndex = null;
         },
         getColorCodeGroup(player: PadelPlayer) {
             if (store.getters.americanoStore.getRules.colorCode === false) {

--- a/src/components/americano/SeedPlayers.vue
+++ b/src/components/americano/SeedPlayers.vue
@@ -1,0 +1,61 @@
+<template>
+    <div>
+        <h4>Seeding</h4>
+        <div
+            v-for="(player, index) in players"
+            :key="player.id"
+            class="seed-item"
+            draggable="true"
+            @dragstart="onDragStart(index)"
+            @dragover.prevent
+            @drop="onDrop(index)"
+        >
+            {{ player.name || 'Player ' + (index + 1) }}
+        </div>
+    </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import store from '@/store/index';
+import { PadelPlayer } from '@/models/padelPlayer.interface';
+
+export default defineComponent({
+    data() {
+        return {
+            dragIndex: null as number | null,
+        };
+    },
+    computed: {
+        players(): PadelPlayer[] {
+            return store.getters.americanoStore.getPlayers;
+        },
+    },
+    methods: {
+        onDragStart(index: number) {
+            this.dragIndex = index;
+        },
+        onDrop(index: number) {
+            if (this.dragIndex === null) {
+                return;
+            }
+            const updated = [...this.players];
+            const moved = updated.splice(this.dragIndex, 1)[0];
+            updated.splice(index, 0, moved);
+            updated.forEach((p, i) => (p.seed = i + 1));
+            store.commit.americanoStore.UPDATE_PLAYERS(updated);
+            this.dragIndex = null;
+        },
+    },
+});
+</script>
+
+<style scoped>
+.seed-item {
+    border: 1px solid #ccc;
+    padding: 4px;
+    margin-bottom: 4px;
+    cursor: grab;
+    background-color: #fff;
+}
+</style>


### PR DESCRIPTION
## Summary
- separate Mexicano seeding from player inputs
- provide dedicated SeedPlayers component with drag & drop
- update README about seeding feature

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6889b839454483328b22d6a5820bd049