### PR TITLE
Rename oversidder and court defaults

### DIFF
--- a/src/components/americano/ShowGames.vue
+++ b/src/components/americano/ShowGames.vue
@@ -54,7 +54,7 @@
                                 </div>
                             </div>
                             <div v-else class="p-2">
-                                Oversidder: {{
+                                Rest round: {{
                                     getPlayerNameById(game.players[0].playerId)
                                 }}
                             </div>
@@ -161,7 +161,7 @@ export default defineComponent({
                 courtIndex = index % courts;
             }
 
-            return this.getCourt(courtIndex) || `Bana ${courtIndex + 1}`;
+            return this.getCourt(courtIndex) || `Court ${courtIndex + 1}`;
         },
         getPlayerNameById(id: number) {
             const player = store.getters.americanoStore.getPlayers.find(


### PR DESCRIPTION
## Summary
- change label "Oversidder" to "Rest round"
- use "Court" instead of "Bana" when no court name is set

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6889c53bd85483328ba41b11690f93bb