### PR TITLE
Setup GitHub Pages workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,31 @@
+name: Deploy to GitHub Pages
+on:
+  push:
+    branches: [ master ]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - id: deploy
+        uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Create match schedules for a Padel Americano completely free of charge. Choose e
 -   [Technologies](#clipboard-technologies)
 -   [Develop](#cloud-develop)
 -   [Contribute](#wrench-contribute)
+-   [Deploy](#rocket-deploy)
 
 ---
 
@@ -69,3 +70,10 @@ $ npm run build
 # :wrench: Contribute
 
 Feel free to contribute, all help is appreciated.
+
+# :rocket: Deploy
+
+Every push to `master` runs a GitHub Actions workflow that builds the project
+and publishes the `dist` folder to **GitHub Pages**. Enable Pages under
+**Settings → Pages** in the repository and choose GitHub Actions as the source
+to make the site available.


### PR DESCRIPTION
## Summary
- add `Deploy to GitHub Pages` workflow that builds on pushes to `master`
- document automatic deploy in README

## Testing
- `npm ci`
- `npm run build` *(fails: TS4104 in SeedPlayers.vue)*

------
https://chatgpt.com/codex/tasks/task_b_6889c7c773788332aa67313b3bcc0b78