### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -40,7 +40,7 @@ export default {
 
 @media (max-width: 623px) {
     html {
-        font-size: 10px;
+        font-size: 14px;
     }
 }
 </style>

--- a/src/assets/theme.css
+++ b/src/assets/theme.css
@@ -13,6 +13,13 @@ body {
     background: linear-gradient(135deg, var(--light-color), #ffffff);
     color: var(--dark-color);
     min-height: 100vh;
+    font-size: 14px;
+}
+
+@media (min-width: 768px) {
+    body {
+        font-size: 16px;
+    }
 }
 
 .navbar-pdl {

--- a/src/components/americano/AddPlayers.vue
+++ b/src/components/americano/AddPlayers.vue
@@ -3,7 +3,7 @@
         <h1 class="text-center">Setup</h1>
         <form @submit.prevent="onAddPlayers">
             <div class="row">
-                <div class="col-6">
+                <div class="col-12 col-md-6">
                     <h4>Add players</h4>
                     <button
                         type="button"
@@ -54,7 +54,7 @@
                         </small>
                     </div>
                 </div>
-                <div class="col-6">
+                <div class="col-12 col-md-6">
                     <h4>Rules</h4>
                     <div>
                         <div class="form-group">

--- a/src/components/americano/ShowGames.vue
+++ b/src/components/americano/ShowGames.vue
@@ -21,7 +21,7 @@
                         >
                             <div
                                 v-if="game.players.length === 4"
-                                class="d-flex flex-row justify-content-between"
+                                class="d-flex flex-column flex-md-row justify-content-between"
                             >
                                 <div class="team-element p-2">
                                     <span class="team">{{
@@ -226,6 +226,16 @@ export default defineComponent({
     background-color: var(--secondary-color);
     border-color: var(--secondary-color);
     color: #fff;
+}
+
+@media (max-width: 767.98px) {
+    .team-element {
+        width: 100%;
+        text-align: center;
+    }
+    .input-element {
+        width: 45px;
+    }
 }
 
 @media print {

--- a/src/components/americano/ShowScore.vue
+++ b/src/components/americano/ShowScore.vue
@@ -1,6 +1,6 @@
 <template>
     <h3 class="text-center md-3">Results</h3>
-    <div v-if="!showTwoTables">
+    <div v-if="!showTwoTables" class="table-responsive">
         <table class="table table-hover">
             <thead>
                 <tr>
@@ -27,7 +27,8 @@
     </div>
     <div v-if="showTwoTables">
         <div class="row">
-            <div class="col-6">
+            <div class="col-12 col-md-6">
+                <div class="table-responsive">
                 <table class="table table-hover">
                     <thead>
                         <tr>
@@ -50,8 +51,10 @@
                         </tr>
                     </tbody>
                 </table>
+                </div>
             </div>
-            <div class="col-6">
+            <div class="col-12 col-md-6">
+                <div class="table-responsive">
                 <table class="table table-hover">
                     <thead>
                         <tr>
@@ -74,6 +77,7 @@
                         </tr>
                     </tbody>
                 </table>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- use larger root font size on small screens
- tweak base body font size for mobile-first layout
- stack player input and rules on small screens
- adjust match layout to wrap on small screens
- make scoreboard tables responsive

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6889e1aa7fd483328541e6c9c1c4fbd8