### PR TITLE
Expand player support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ![Feber Enhancer Demo](public/padel-demo.png)
 
-Create match schedules for a Padel Americano completely free of charge. Choose either 8 or 16 players and fill in the scores to calculate the winner.
+Create match schedules for a Padel Americano completely free of charge. Choose any number of players up to 64 and fill in the scores to calculate the winner.
 
 # Table of Contents
 
@@ -32,7 +32,7 @@ Create match schedules for a Padel Americano completely free of charge. Choose e
 # :heavy_check_mark: Features
 
 -   Create a schedule for Padel Americano
--   Choose between 4 and 16 players
+-   Choose between 4 and 64 players
 -   Choose maximum points per round (default is 24)
 -   Shuffle the schedule
 -   Color code the group split when using 16 players

--- a/src/components/americano/AddPlayers.vue
+++ b/src/components/americano/AddPlayers.vue
@@ -527,7 +527,7 @@ export default defineComponent({
         },
         playerOptions() {
             const options: number[] = [];
-            for (let i = 4; i <= 16; i++) {
+            for (let i = 4; i <= 64; i++) {
                 options.push(i);
             }
             return options;


### PR DESCRIPTION
## Summary
- allow up to 64 players to be configured
- document new player limits

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6889fd1170048332ae6c77ed7d672aa4