### PR TITLE
Add clickable padel court score input

### DIFF
--- a/src/components/americano/CourtGame.vue
+++ b/src/components/americano/CourtGame.vue
@@ -1,0 +1,141 @@
+<template>
+    <div
+        class="court-container"
+        :class="{
+            'is-second': game.playGroup === 2,
+            'is-first': game.playGroup === 1,
+        }"
+    >
+        <div class="team left">{{ getPlayerNames(game, GameSide.Home) }}</div>
+        <div class="score-select">
+            <div class="circle" @click="selectScore(GameSide.Home)">
+                <span v-if="game.homeScore === null">?</span>
+                <span v-else>{{ game.homeScore }}</span>
+            </div>
+            <div class="circle" @click="selectScore(GameSide.Away)">
+                <span v-if="game.awayScore === null">?</span>
+                <span v-else>{{ game.awayScore }}</span>
+            </div>
+        </div>
+        <div class="team right">{{ getPlayerNames(game, GameSide.Away) }}</div>
+
+        <div v-if="activeSide !== null" class="score-popup">
+            <button
+                v-for="n in maxScore + 1"
+                :key="n - 1"
+                @click="setScore(n - 1)"
+            >
+                {{ n - 1 }}
+            </button>
+        </div>
+    </div>
+</template>
+
+<script lang="ts">
+/* eslint-disable vue/no-mutating-props */
+import { defineComponent, PropType } from "vue";
+import { PadelGame } from "@/models/padelGame.interface";
+import { GameSide } from "@/models/gameSide.enum";
+import { getFullPlayerNames } from "@/services/htmlHelperService";
+import { evenScore, removeNotNumbers } from "@/services/scoreService";
+import store from "@/store/index";
+
+export default defineComponent({
+    props: {
+        game: {
+            type: Object as PropType<PadelGame>,
+            required: true,
+        },
+    },
+    data() {
+        return {
+            activeSide: null as GameSide | null,
+        };
+    },
+    computed: {
+        maxScore() {
+            return store.getters.americanoStore.getRules.maxScore;
+        },
+    },
+    methods: {
+        getPlayerNames(game: PadelGame, side: GameSide) {
+            return getFullPlayerNames(game, side);
+        },
+        selectScore(side: GameSide) {
+            this.activeSide = side;
+        },
+        setScore(value: number) {
+            if (this.activeSide === GameSide.Home) {
+                this.game.homeScore = value;
+            } else if (this.activeSide === GameSide.Away) {
+                this.game.awayScore = value;
+            }
+            if (this.activeSide !== null) {
+                removeNotNumbers(this.game, this.activeSide, this.maxScore);
+                evenScore(this.game, this.maxScore, this.activeSide);
+                store.dispatch.americanoStore.saveStateManually();
+            }
+            this.activeSide = null;
+        },
+    },
+    components: {},
+});
+</script>
+
+<style scoped>
+.court-container {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    background-color: var(--light-color);
+    padding: 0.5rem;
+    border: 1px solid var(--primary-color);
+    border-radius: 0.375rem;
+    margin-bottom: 1rem;
+}
+.team {
+    width: 40%;
+    text-align: center;
+    font-weight: bold;
+}
+.score-select {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+.circle {
+    width: 40px;
+    height: 40px;
+    margin: 2px 0;
+    background-color: var(--secondary-color);
+    color: #fff;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+}
+.score-popup {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: #fff;
+    border: 1px solid var(--primary-color);
+    padding: 0.5rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    z-index: 10;
+}
+.score-popup button {
+    border: none;
+    background-color: var(--secondary-color);
+    color: #fff;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    cursor: pointer;
+}
+</style>

--- a/src/components/americano/ShowGames.vue
+++ b/src/components/americano/ShowGames.vue
@@ -5,10 +5,7 @@
             <div class="form-group">
                 <div class="score-container">
                     <div v-for="(game, index) in getGames" :key="game.id">
-                        <div
-                            v-if="IsNewRound(index)"
-                            class="score-round"
-                        >
+                        <div v-if="IsNewRound(index)" class="score-round">
                             Round: {{ game.round }}
                         </div>
                         <div
@@ -19,42 +16,15 @@
                             }"
                             class="game-container"
                         >
-                            <div
-                                v-if="game.players.length === 4"
-                                class="d-flex flex-column flex-md-row justify-content-between"
-                            >
-                                <div class="team-element p-2">
-                                    <span class="team">{{
-                                        getPlayerNames(game, 1)
-                                    }}</span>
-                                    <span class="vs"> vs </span>
-                                    <span class="team">{{
-                                        getPlayerNames(game, 2)
-                                    }}</span>
-                                </div>
-
-                                <span class="team-element pt-2">
-                                    {{ printCourt(game, index) }}</span
-                                >
-
-                                <div class="team-element p-2 align-self-center">
-                                    <input
-                                        v-model="game.homeScore"
-                                        class="input-element"
-                                        required
-                                        @focusout="handleFocusChange(game, 1)"
-                                    />
-                                    -
-                                    <input
-                                        v-model="game.awayScore"
-                                        class="input-element"
-                                        required
-                                        @focusout="handleFocusChange(game, 2)"
-                                    />
+                            <div v-if="game.players.length === 4">
+                                <CourtGame :game="game" />
+                                <div class="text-center court-name">
+                                    {{ printCourt(game, index) }}
                                 </div>
                             </div>
                             <div v-else class="p-2">
-                                Rest round: {{
+                                Rest round:
+                                {{
                                     getPlayerNameById(game.players[0].playerId)
                                 }}
                             </div>
@@ -94,10 +64,11 @@ import { defineComponent } from "vue";
 import store from "@/store/index";
 import { PadelGame } from "@/models/padelGame.interface";
 import { getFullPlayerNames } from "@/services/htmlHelperService";
-import { evenScore, removeNotNumbers } from "@/services/scoreService";
 import { GameSide } from "@/models/gameSide.enum";
+import CourtGame from "./CourtGame.vue";
 
 export default defineComponent({
+    components: { CourtGame },
     methods: {
         onCalculateScore(): void {
             store.dispatch.americanoStore.updatePlayerScores();
@@ -122,19 +93,6 @@ export default defineComponent({
         },
         reset(): void {
             store.commit.americanoStore.RESET();
-        },
-        handleFocusChange(game: PadelGame, side: GameSide) {
-            removeNotNumbers(
-                game,
-                side,
-                store.getters.americanoStore.getRules.maxScore
-            );
-            evenScore(
-                game,
-                store.getters.americanoStore.getRules.maxScore,
-                side
-            );
-            store.dispatch.americanoStore.saveStateManually();
         },
         getColorCodeGroup(game: PadelGame) {
             if (store.getters.americanoStore.getRules.colorCode === false) {
@@ -205,19 +163,6 @@ export default defineComponent({
     color: var(--dark-color);
 }
 
-.vs {
-    color: #e74c3c;
-}
-
-.vs-element {
-    width: 150px;
-}
-
-.input-element {
-    width: 35px;
-    text-align: center;
-}
-
 .top-border {
     border-top: 0.1rem solid var(--primary-color);
 }
@@ -226,16 +171,6 @@ export default defineComponent({
     background-color: var(--secondary-color);
     border-color: var(--secondary-color);
     color: #fff;
-}
-
-@media (max-width: 767.98px) {
-    .team-element {
-        width: 100%;
-        text-align: center;
-    }
-    .input-element {
-        width: 45px;
-    }
 }
 
 @media print {


### PR DESCRIPTION
## Summary
- show each game using new `<CourtGame>` component with padel court layout
- add interactive circle buttons to choose the score and automatically calculate the opponent's score

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_688a123330b4833286a22da0ce7e9a4a