### PR TITLE
Add match view with interactive scoring

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,6 +1,7 @@
 import { createRouter, createWebHistory, RouteRecordRaw } from "vue-router";
 import Americano from "../views/Americano.vue";
 import TestSimulation from "../views/TestSimulation.vue";
+import MatchView from "../views/MatchView.vue";
 
 const routes: Array<RouteRecordRaw> = [
     {
@@ -12,6 +13,11 @@ const routes: Array<RouteRecordRaw> = [
         path: "/test",
         name: "TestSimulation",
         component: TestSimulation,
+    },
+    {
+        path: "/match",
+        name: "MatchView",
+        component: MatchView,
     },
     // {
     //     path: "/about",

--- a/src/views/MatchView.vue
+++ b/src/views/MatchView.vue
@@ -1,0 +1,155 @@
+<template>
+    <div class="match-wrapper">
+        <div class="court">
+            <div class="half left">
+                <div class="player-name">{{ homeName }}</div>
+                <div class="score-circle" @click="openOverlay('home')">
+                    {{ homeScore === null ? "?" : homeScore }}
+                </div>
+            </div>
+            <div class="net"></div>
+            <div class="half right">
+                <div class="player-name">{{ awayName }}</div>
+                <div class="score-circle" @click="openOverlay('away')">
+                    {{ awayScore === null ? "?" : awayScore }}
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="overlay" v-if="overlayOpen">
+        <div class="grid">
+            <button
+                v-for="n in maxPoints + 1"
+                :key="n"
+                class="grid-btn"
+                @click="selectScore(n - 1)"
+            >
+                {{ n - 1 }}
+            </button>
+        </div>
+    </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+
+export default defineComponent({
+    data() {
+        return {
+            homeName: "Hold A",
+            awayName: "Hold B",
+            maxPoints: 21,
+            homeScore: null as number | null,
+            awayScore: null as number | null,
+            activeTeam: "" as "home" | "away" | "",
+            overlayOpen: false,
+        };
+    },
+    methods: {
+        openOverlay(team: "home" | "away") {
+            if (this.homeScore !== null || this.awayScore !== null) return;
+            this.activeTeam = team;
+            this.overlayOpen = true;
+        },
+        selectScore(score: number) {
+            if (this.activeTeam === "home") {
+                this.homeScore = score;
+                this.awayScore = this.maxPoints - score;
+            } else if (this.activeTeam === "away") {
+                this.awayScore = score;
+                this.homeScore = this.maxPoints - score;
+            }
+            this.overlayOpen = false;
+        },
+    },
+});
+</script>
+
+<style scoped>
+.match-wrapper {
+    display: flex;
+    justify-content: center;
+    margin-top: 2rem;
+}
+.court {
+    position: relative;
+    width: 320px;
+    height: 500px;
+    background: #d2b48c;
+    border: 4px solid #ffffff;
+}
+.half {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 50%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+}
+.left {
+    left: 0;
+    border-right: 2px solid #ffffff;
+}
+.right {
+    right: 0;
+    border-left: 2px solid #ffffff;
+}
+.net {
+    position: absolute;
+    top: 50%;
+    left: 0;
+    width: 100%;
+    height: 3px;
+    background: #ffffff;
+    transform: translateY(-50%);
+}
+.player-name {
+    position: absolute;
+    top: 10px;
+    font-weight: bold;
+    color: var(--dark-color);
+}
+.score-circle {
+    width: 80px;
+    height: 80px;
+    border-radius: 50%;
+    background: var(--secondary-color);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-size: 2rem;
+    color: #fff;
+    cursor: pointer;
+}
+.overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.6);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+.grid {
+    background: #fff;
+    padding: 1rem;
+    border-radius: 8px;
+    display: grid;
+    grid-template-columns: repeat(6, 50px);
+    gap: 0.5rem;
+}
+.grid-btn {
+    width: 50px;
+    height: 50px;
+    border-radius: 50%;
+    border: none;
+    background: var(--accent-color);
+    color: #fff;
+    font-weight: bold;
+    cursor: pointer;
+}
+</style>

--- a/src/views/Nav.vue
+++ b/src/views/Nav.vue
@@ -20,6 +20,9 @@
                 <router-link class="nav-item nav-link" to="/test"
                     >Test</router-link
                 >
+                <router-link class="nav-item nav-link" to="/match"
+                    >Match</router-link
+                >
             </div>
         </div>
     </nav>


### PR DESCRIPTION
## Summary
- add `MatchView` with court layout, scoring circles, and number overlay
- register the new view in the router
- expose link to Match view in navigation

## Testing
- `node_modules/.bin/prettier --write src/views/MatchView.vue src/router/index.ts src/views/Nav.vue`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_688a1a287cb883328a607ba14ad283a0