### PR TITLE
Add match scoring overlay

### DIFF
--- a/src/components/americano/MatchCourt.vue
+++ b/src/components/americano/MatchCourt.vue
@@ -1,0 +1,183 @@
+<template>
+    <div class="match-wrapper">
+        <div class="court">
+            <div class="half left">
+                <div class="player-name">{{ homeName }}</div>
+                <div class="score-circle" @click="openOverlay('home')">
+                    {{ game.homeScore === null ? "?" : game.homeScore }}
+                </div>
+            </div>
+            <div class="net"></div>
+            <div class="half right">
+                <div class="player-name">{{ awayName }}</div>
+                <div class="score-circle" @click="openOverlay('away')">
+                    {{ game.awayScore === null ? "?" : game.awayScore }}
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="overlay" v-if="overlayOpen" @click.self="overlayOpen = false">
+        <div class="grid">
+            <button
+                v-for="n in maxPoints + 1"
+                :key="n"
+                class="grid-btn"
+                @click="selectScore(n - 1)"
+            >
+                {{ n - 1 }}
+            </button>
+        </div>
+    </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, PropType } from "vue";
+import { PadelGame } from "@/models/padelGame.interface";
+import store from "@/store/index";
+
+export default defineComponent({
+    emits: ["set-score"],
+    props: {
+        game: {
+            type: Object as PropType<PadelGame>,
+            required: true,
+        },
+        homeName: {
+            type: String,
+            required: true,
+        },
+        awayName: {
+            type: String,
+            required: true,
+        },
+        maxPoints: {
+            type: Number,
+            required: true,
+        },
+    },
+    data() {
+        return {
+            overlayOpen: false,
+            activeTeam: "" as "home" | "away" | "",
+        };
+    },
+    methods: {
+        openOverlay(team: "home" | "away") {
+            if (this.game.homeScore !== null || this.game.awayScore !== null)
+                return;
+            this.activeTeam = team;
+            this.overlayOpen = true;
+        },
+        selectScore(score: number) {
+            if (this.activeTeam === "home") {
+                const homeScore = score;
+                const awayScore = this.maxPoints - score;
+                this.$emit("set-score", {
+                    game: this.game,
+                    homeScore,
+                    awayScore,
+                });
+            } else if (this.activeTeam === "away") {
+                const awayScore = score;
+                const homeScore = this.maxPoints - score;
+                this.$emit("set-score", {
+                    game: this.game,
+                    homeScore,
+                    awayScore,
+                });
+            }
+            this.overlayOpen = false;
+            store.dispatch.americanoStore.saveStateManually();
+        },
+    },
+});
+</script>
+
+<style scoped>
+.match-wrapper {
+    display: flex;
+    justify-content: center;
+    margin: 1rem 0;
+}
+.court {
+    position: relative;
+    width: 320px;
+    height: 160px;
+    background: #d2b48c;
+    border: 4px solid #ffffff;
+}
+.half {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 50%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+}
+.left {
+    left: 0;
+    border-right: 2px solid #ffffff;
+}
+.right {
+    right: 0;
+    border-left: 2px solid #ffffff;
+}
+.net {
+    position: absolute;
+    top: 50%;
+    left: 0;
+    width: 100%;
+    height: 3px;
+    background: #ffffff;
+    transform: translateY(-50%);
+}
+.player-name {
+    position: absolute;
+    top: 10px;
+    font-weight: bold;
+    color: var(--dark-color);
+}
+.score-circle {
+    width: 60px;
+    height: 60px;
+    border-radius: 50%;
+    background: var(--secondary-color);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-size: 1.5rem;
+    color: #fff;
+    cursor: pointer;
+}
+.overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.6);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+.grid {
+    background: #fff;
+    padding: 1rem;
+    border-radius: 8px;
+    display: grid;
+    grid-template-columns: repeat(6, 50px);
+    gap: 0.5rem;
+}
+.grid-btn {
+    width: 50px;
+    height: 50px;
+    border-radius: 50%;
+    border: none;
+    background: var(--accent-color);
+    color: #fff;
+    font-weight: bold;
+    cursor: pointer;
+}
+</style>

--- a/src/components/americano/ShowGames.vue
+++ b/src/components/americano/ShowGames.vue
@@ -5,10 +5,7 @@
             <div class="form-group">
                 <div class="score-container">
                     <div v-for="(game, index) in getGames" :key="game.id">
-                        <div
-                            v-if="IsNewRound(index)"
-                            class="score-round"
-                        >
+                        <div v-if="IsNewRound(index)" class="score-round">
                             Round: {{ game.round }}
                         </div>
                         <div
@@ -23,38 +20,20 @@
                                 v-if="game.players.length === 4"
                                 class="d-flex flex-column flex-md-row justify-content-between"
                             >
-                                <div class="team-element p-2">
-                                    <span class="team">{{
-                                        getPlayerNames(game, 1)
-                                    }}</span>
-                                    <span class="vs"> vs </span>
-                                    <span class="team">{{
-                                        getPlayerNames(game, 2)
-                                    }}</span>
-                                </div>
-
                                 <span class="team-element pt-2">
-                                    {{ printCourt(game, index) }}</span
-                                >
-
-                                <div class="team-element p-2 align-self-center">
-                                    <input
-                                        v-model="game.homeScore"
-                                        class="input-element"
-                                        required
-                                        @focusout="handleFocusChange(game, 1)"
-                                    />
-                                    -
-                                    <input
-                                        v-model="game.awayScore"
-                                        class="input-element"
-                                        required
-                                        @focusout="handleFocusChange(game, 2)"
-                                    />
-                                </div>
+                                    {{ printCourt(game, index) }}
+                                </span>
+                                <MatchCourt
+                                    :game="game"
+                                    :homeName="getPlayerNames(game, 1)"
+                                    :awayName="getPlayerNames(game, 2)"
+                                    :maxPoints="getRules.maxScore"
+                                    @set-score="updateScore"
+                                />
                             </div>
                             <div v-else class="p-2">
-                                Rest round: {{
+                                Rest round:
+                                {{
                                     getPlayerNameById(game.players[0].playerId)
                                 }}
                             </div>
@@ -94,7 +73,6 @@ import { defineComponent } from "vue";
 import store from "@/store/index";
 import { PadelGame } from "@/models/padelGame.interface";
 import { getFullPlayerNames } from "@/services/htmlHelperService";
-import { evenScore, removeNotNumbers } from "@/services/scoreService";
 import { GameSide } from "@/models/gameSide.enum";
 
 export default defineComponent({
@@ -123,18 +101,13 @@ export default defineComponent({
         reset(): void {
             store.commit.americanoStore.RESET();
         },
-        handleFocusChange(game: PadelGame, side: GameSide) {
-            removeNotNumbers(
-                game,
-                side,
-                store.getters.americanoStore.getRules.maxScore
-            );
-            evenScore(
-                game,
-                store.getters.americanoStore.getRules.maxScore,
-                side
-            );
-            store.dispatch.americanoStore.saveStateManually();
+        updateScore(payload: {
+            game: PadelGame;
+            homeScore: number;
+            awayScore: number;
+        }) {
+            payload.game.homeScore = payload.homeScore;
+            payload.game.awayScore = payload.awayScore;
         },
         getColorCodeGroup(game: PadelGame) {
             if (store.getters.americanoStore.getRules.colorCode === false) {


### PR DESCRIPTION
## Summary
- embed interactive match court in game list
- remove unused Match view route and link
- create reusable `MatchCourt` component for selecting scores

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_688a1a287cb883328a607ba14ad283a0