### PR TITLE
Show sides in schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Create match schedules for a Padel Americano completely free of charge. Choose a
 -   Automatically calculate the opponent's points
 -   Enter match results to determine the winner
 -   Separate seeding list with drag and drop for Mexicano mode
+-   Show which side each player should play and balance "Both" players
 
 # :clipboard: Technologies
 

--- a/src/components/americano/ShowGames.vue
+++ b/src/components/americano/ShowGames.vue
@@ -5,10 +5,7 @@
             <div class="form-group">
                 <div class="score-container">
                     <div v-for="(game, index) in getGames" :key="game.id">
-                        <div
-                            v-if="IsNewRound(index)"
-                            class="score-round"
-                        >
+                        <div v-if="IsNewRound(index)" class="score-round">
                             Round: {{ game.round }}
                         </div>
                         <div
@@ -54,7 +51,8 @@
                                 </div>
                             </div>
                             <div v-else class="p-2">
-                                Rest round: {{
+                                Rest round:
+                                {{
                                     getPlayerNameById(game.players[0].playerId)
                                 }}
                             </div>
@@ -93,7 +91,7 @@
 import { defineComponent } from "vue";
 import store from "@/store/index";
 import { PadelGame } from "@/models/padelGame.interface";
-import { getFullPlayerNames } from "@/services/htmlHelperService";
+import { getFullPlayerNamesWithSide } from "@/services/htmlHelperService";
 import { evenScore, removeNotNumbers } from "@/services/scoreService";
 import { GameSide } from "@/models/gameSide.enum";
 
@@ -108,7 +106,7 @@ export default defineComponent({
             return games[index].round !== games[index - 1].round;
         },
         getPlayerNames(game: PadelGame, side: GameSide) {
-            return getFullPlayerNames(game, side);
+            return getFullPlayerNamesWithSide(game, side);
         },
         shouldHaveTopBorder(game: PadelGame) {
             const lastTwoGamesOfFour = game.matchNumber == 2;

--- a/src/services/htmlHelperService.ts
+++ b/src/services/htmlHelperService.ts
@@ -37,6 +37,38 @@ export function getFullPlayerNames(game: PadelGame, side: GameSide) {
     return `${firstPlayer.name} & ${secondPlayer.name}`;
 }
 
+export function getFullPlayerNamesWithSide(game: PadelGame, side: GameSide) {
+    const isHome = side === GameSide.Home;
+
+    const players = game.players.filter(p => p.home === isHome);
+
+    const short = (s?: string) => (s === "Right" ? "R" : "L");
+
+    if (players.length === 0) {
+        return "";
+    }
+
+    const first = store.getters.americanoStore.getPlayers.find(
+        p => p.id === players[0].playerId
+    );
+
+    if (players.length === 1) {
+        return first ? `${first.name} (${short(players[0].side)})` : "";
+    }
+
+    const second = store.getters.americanoStore.getPlayers.find(
+        p => p.id === players[1].playerId
+    );
+
+    if (!first || !second) {
+        return "";
+    }
+
+    return `${first.name} (${short(players[0].side)}) & ${second.name} (${short(
+        players[1].side
+    )})`;
+}
+
 export function isValidMaxScore(value: number): boolean {
     if (!value) {
         return false;

--- a/src/services/mexicanoService.ts
+++ b/src/services/mexicanoService.ts
@@ -1,5 +1,6 @@
 import { PadelGame } from "@/models/padelGame.interface";
 import { PadelPlayer, PreferredSide } from "@/models/padelPlayer.interface";
+import { balancePlayerSides } from "./americanoService";
 
 function chooseSides(
     first: PadelPlayer,
@@ -70,6 +71,8 @@ export function prepareMexicanoRound(
             playGroup: 1,
         });
     }
+
+    balancePlayerSides(games, players);
 
     return games;
 }


### PR DESCRIPTION
## Summary
- display players' sides on the schedule
- keep "Both" players balanced on left and right
- show the new capability in docs

## Testing
- `npm run format`
- `npx prettier --write src/services/americanoService.ts src/services/mexicanoService.ts src/services/htmlHelperService.ts src/components/americano/ShowGames.vue README.md`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_688a23d4fb248332a2714b5fcf3bc622