### PR TITLE
Add per round results

### DIFF
--- a/src/services/americanoService.ts
+++ b/src/services/americanoService.ts
@@ -709,3 +709,11 @@ export function allNamesAreEmpty(players: PadelPlayer[]) {
     const namedPlayers = players.filter(player => player.name !== "");
     return namedPlayers.length === 0;
 }
+
+export function getMaxRound(games: PadelGame[]): number {
+    if (games.length === 0) {
+        return 0;
+    }
+
+    return Math.max(...games.map(g => g.round));
+}

--- a/src/store/modules/americanoStore.ts
+++ b/src/store/modules/americanoStore.ts
@@ -193,20 +193,6 @@ export default {
             );
             commit("UPDATE_PLAYERS", updatedPlayers);
 
-            if (getters.getRules.mode === "Mexicano") {
-                if (getters.getRound >= totalRounds(getters.getPlayers.length)) {
-                    commit("INCREMENT_STEP");
-                } else {
-                    commit("INCREMENT_ROUND");
-                    const nextGames = prepareMexicanoRound(
-                        getters.getPlayers,
-                        getters.getRound
-                    );
-                    commit("UPDATE_GAMES", nextGames);
-                }
-                return;
-            }
-
             commit("INCREMENT_STEP");
         },
         sortPlayersByScore({ commit, getters }: AmericanoStoreActions) {
@@ -228,6 +214,20 @@ export default {
                 getters.getRules,
                 getters.getRound
             );
+        },
+        nextRound({ commit, getters }: AmericanoStoreActions) {
+            if (getters.getRules.mode === "Mexicano") {
+                if (getters.getRound < totalRounds(getters.getPlayers.length)) {
+                    commit("INCREMENT_ROUND");
+                    const nextGames = prepareMexicanoRound(
+                        getters.getPlayers,
+                        getters.getRound
+                    );
+                    commit("UPDATE_GAMES", nextGames);
+                }
+            }
+
+            commit("DECREMENT_STEP");
         },
     },
     getters: {


### PR DESCRIPTION
## Summary
- show current standings after each round
- allow continuing to next round in Mexicano
- expose max round helper

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_688a2abe731883329820ca0a50822837