### PR TITLE
Add multi-tournament support

### DIFF
--- a/src/components/americano/AddPlayers.vue
+++ b/src/components/americano/AddPlayers.vue
@@ -4,6 +4,18 @@
         <form @submit.prevent="onAddPlayers">
             <div class="row">
                 <div class="col-12 col-md-6">
+                    <div class="form-group">
+                        <label for="tournamentName" class="form-label"
+                            >Tournament name</label
+                        >
+                        <input
+                            id="tournamentName"
+                            type="text"
+                            class="form-control"
+                            v-model="tournamentNameRule"
+                            required
+                        />
+                    </div>
                     <h4>Add players</h4>
                     <button
                         type="button"
@@ -152,13 +164,21 @@
                                 class="d-flex flex-row flex-wrap"
                                 id="courtNames"
                             >
-                                <template v-for="index in numberOfCourts" :key="index">
+                                <template
+                                    v-for="index in numberOfCourts"
+                                    :key="index"
+                                >
                                     <input
                                         type="text"
                                         class="form-control m-2"
                                         :placeholder="`Court ${index}`"
                                         :value="courtNamesRule[index - 1]"
-                                        @input="updateCourtName(index - 1, $event.target.value)"
+                                        @input="
+                                            updateCourtName(
+                                                index - 1,
+                                                $event.target.value
+                                            )
+                                        "
                                     />
                                 </template>
                             </div>
@@ -267,7 +287,7 @@ import SeedPlayers from "@/components/americano/SeedPlayers.vue";
 
 export default defineComponent({
     components: { SeedPlayers },
-    data: function() {
+    data: function () {
         return {
             maxScore: 24,
             maxScoreInvalid: false,
@@ -452,6 +472,9 @@ export default defineComponent({
             },
             deep: true,
         },
+        tournamentNameRule() {
+            store.dispatch.americanoStore.saveStateManually();
+        },
     },
     computed: {
         getPlayers() {
@@ -543,6 +566,14 @@ export default defineComponent({
         },
         numberOfCourts() {
             return Math.floor(this.amountOfPlayersRule / 4);
+        },
+        tournamentNameRule: {
+            get() {
+                return store.getters.americanoStore.getTournamentName;
+            },
+            set(value: string) {
+                store.commit.americanoStore.SET_TOURNAMENT_NAME(value);
+            },
         },
     },
 });

--- a/src/services/storageService.ts
+++ b/src/services/storageService.ts
@@ -3,30 +3,64 @@ import { PadelGame } from "@/models/padelGame.interface";
 import { PadelPlayer } from "@/models/padelPlayer.interface";
 import { PadelRules } from "@/models/padelRules.interface";
 
-const _fullAmericanoState = "fullAmericanoState";
+const _tournaments = "fullAmericanoTournaments";
+const _currentTournament = "currentAmericanoTournament";
+
+function loadTournaments(): Record<string, FullAmericanoState> {
+    const loaded = localStorage.getItem(_tournaments);
+    return loaded ? JSON.parse(loaded) : {};
+}
+
+export function getTournamentNames(): string[] {
+    return Object.keys(loadTournaments());
+}
+
+export function getCurrentTournamentName(): string | null {
+    return localStorage.getItem(_currentTournament);
+}
 
 export function saveAmericanoState(
     players: PadelPlayer[],
     games: PadelGame[],
     step: number,
     rules: PadelRules,
-    round: number
+    round: number,
+    name: string
 ): void {
-    const saveObject: FullAmericanoState = { players, games, step, rules, round };
+    const saveObject: FullAmericanoState = {
+        players,
+        games,
+        step,
+        rules,
+        round,
+    };
 
-    localStorage.setItem(_fullAmericanoState, JSON.stringify(saveObject));
+    const tournaments = loadTournaments();
+    tournaments[name] = saveObject;
+    localStorage.setItem(_tournaments, JSON.stringify(tournaments));
+    localStorage.setItem(_currentTournament, name);
 }
 
-export function loadAmericanoState(): FullAmericanoState | null {
-    const loadedState = localStorage.getItem(_fullAmericanoState);
+export function loadAmericanoState(name?: string): FullAmericanoState | null {
+    if (!name) {
+        name = localStorage.getItem(_currentTournament) || undefined;
+    }
 
-    if (loadedState === null) {
+    if (!name) {
         return null;
     }
 
-    return JSON.parse(loadedState);
+    const tournaments = loadTournaments();
+    return tournaments[name] || null;
 }
 
-export function removeAmericanoState(): void {
-    localStorage.removeItem(_fullAmericanoState);
+export function removeAmericanoState(name: string): void {
+    const tournaments = loadTournaments();
+    delete tournaments[name];
+    localStorage.setItem(_tournaments, JSON.stringify(tournaments));
+
+    const current = localStorage.getItem(_currentTournament);
+    if (current === name) {
+        localStorage.removeItem(_currentTournament);
+    }
 }

--- a/src/store/modules/americanoStore.ts
+++ b/src/store/modules/americanoStore.ts
@@ -12,14 +12,12 @@ import {
     sortByScore,
     updatePlayerScores,
 } from "@/services/scoreService";
-import {
-    prepareMexicanoRound,
-    totalRounds,
-} from "@/services/mexicanoService";
+import { prepareMexicanoRound, totalRounds } from "@/services/mexicanoService";
 import {
     loadAmericanoState,
     removeAmericanoState,
     saveAmericanoState,
+    getCurrentTournamentName,
 } from "@/services/storageService";
 
 export interface AmericanoStoreState {
@@ -29,6 +27,7 @@ export interface AmericanoStoreState {
     isGamePrepared: boolean;
     rules: PadelRules;
     round: number;
+    tournamentName: string;
 }
 
 export interface AmericanoStoreGetters {
@@ -38,6 +37,7 @@ export interface AmericanoStoreGetters {
     getIsGamePrepared: boolean;
     getRules: PadelRules;
     getRound: number;
+    getTournamentName: string;
 }
 
 export interface AmericanoStoreActions {
@@ -55,6 +55,7 @@ export default {
         step: 1,
         isGamePrepared: false,
         round: 1,
+        tournamentName: new Date().toISOString().slice(0, 10),
         rules: {
             maxScore: 32,
             randomSchedule: false,
@@ -73,13 +74,13 @@ export default {
                 state.games,
                 state.step,
                 state.rules,
-                state.round
+                state.round,
+                state.tournamentName
             );
         },
         UPDATE_PLAYERS(state: AmericanoStoreState, players: PadelPlayer[]) {
             state.players = players;
             state.rules.amountOfPlayers = players.length;
-
 
             if (allNamesAreEmpty(players)) {
                 return;
@@ -90,7 +91,8 @@ export default {
                 state.games,
                 state.step,
                 state.rules,
-                state.round
+                state.round,
+                state.tournamentName
             );
         },
         INCREMENT_STEP(state: AmericanoStoreState) {
@@ -100,7 +102,8 @@ export default {
                 state.games,
                 state.step,
                 state.rules,
-                state.round
+                state.round,
+                state.tournamentName
             );
         },
         INCREMENT_ROUND(state: AmericanoStoreState) {
@@ -110,7 +113,8 @@ export default {
                 state.games,
                 state.step,
                 state.rules,
-                state.round
+                state.round,
+                state.tournamentName
             );
         },
         DECREMENT_STEP(state: AmericanoStoreState) {
@@ -120,7 +124,8 @@ export default {
                 state.games,
                 state.step,
                 state.rules,
-                state.round
+                state.round,
+                state.tournamentName
             );
         },
         SET_RULES(state: AmericanoStoreState, rules: PadelRules) {
@@ -130,7 +135,19 @@ export default {
                 state.games,
                 state.step,
                 state.rules,
-                state.round
+                state.round,
+                state.tournamentName
+            );
+        },
+        SET_TOURNAMENT_NAME(state: AmericanoStoreState, name: string) {
+            state.tournamentName = name;
+            saveAmericanoState(
+                state.players,
+                state.games,
+                state.step,
+                state.rules,
+                state.round,
+                state.tournamentName
             );
         },
         RESET(state: AmericanoStoreState) {
@@ -145,11 +162,16 @@ export default {
             state.rules.colorCode = false;
             state.rules.courtNames = Array(16).fill("");
             state.rules.mode = "Americano";
-            removeAmericanoState();
+            removeAmericanoState(state.tournamentName);
+            state.tournamentName = new Date().toISOString().slice(0, 10);
         },
         LOAD_STATE(state: AmericanoStoreState) {
-
             const americanoState = loadAmericanoState();
+
+            const currentName = getCurrentTournamentName();
+            if (currentName) {
+                state.tournamentName = currentName;
+            }
 
             if (!americanoState) {
                 return;
@@ -175,7 +197,10 @@ export default {
     actions: {
         prepareGames({ commit, getters }: AmericanoStoreActions) {
             if (getters.getRules.mode === "Mexicano") {
-                const games = prepareMexicanoRound(getters.getPlayers, getters.getRound);
+                const games = prepareMexicanoRound(
+                    getters.getPlayers,
+                    getters.getRound
+                );
                 commit("UPDATE_GAMES", games);
             } else {
                 const games = prepareGames(
@@ -212,7 +237,8 @@ export default {
                 getters.getGames,
                 getters.getStep,
                 getters.getRules,
-                getters.getRound
+                getters.getRound,
+                getters.getTournamentName
             );
         },
         nextRound({ commit, getters }: AmericanoStoreActions) {
@@ -237,5 +263,6 @@ export default {
         getIsGamePrepared: (state: AmericanoStoreState) => state.isGamePrepared,
         getRules: (state: AmericanoStoreState) => state.rules,
         getRound: (state: AmericanoStoreState) => state.round,
+        getTournamentName: (state: AmericanoStoreState) => state.tournamentName,
     },
 };


### PR DESCRIPTION
## Summary
- allow storing many tournaments in localStorage
- track current tournament name
- include tournament name field in setup
- persist tournament name in store

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_688a3b7493148332bf51a82d7b0cbdde