### PR TITLE
Add tournament selector

### DIFF
--- a/src/components/americano/AddPlayers.vue
+++ b/src/components/americano/AddPlayers.vue
@@ -4,6 +4,27 @@
         <form @submit.prevent="onAddPlayers">
             <div class="row">
                 <div class="col-12 col-md-6">
+                    <div class="form-group">
+                        <label for="tournamentName" class="form-label"
+                            >Tournament name</label
+                        >
+                        <input
+                            id="tournamentName"
+                            type="text"
+                            class="form-control"
+                            list="tournamentNames"
+                            v-model="tournamentNameRule"
+                            @change="onTournamentChange"
+                            required
+                        />
+                        <datalist id="tournamentNames">
+                            <option
+                                v-for="name in tournamentNames"
+                                :key="name"
+                                :value="name"
+                            />
+                        </datalist>
+                    </div>
                     <h4>Add players</h4>
                     <button
                         type="button"
@@ -152,13 +173,21 @@
                                 class="d-flex flex-row flex-wrap"
                                 id="courtNames"
                             >
-                                <template v-for="index in numberOfCourts" :key="index">
+                                <template
+                                    v-for="index in numberOfCourts"
+                                    :key="index"
+                                >
                                     <input
                                         type="text"
                                         class="form-control m-2"
                                         :placeholder="`Court ${index}`"
                                         :value="courtNamesRule[index - 1]"
-                                        @input="updateCourtName(index - 1, $event.target.value)"
+                                        @input="
+                                            updateCourtName(
+                                                index - 1,
+                                                $event.target.value
+                                            )
+                                        "
                                     />
                                 </template>
                             </div>
@@ -263,11 +292,12 @@ import {
 import { getDuplicateIds, isValidMaxScore } from "@/services/htmlHelperService";
 import store from "@/store/index";
 import { defineComponent } from "vue";
+import { getTournamentNames } from "@/services/storageService";
 import SeedPlayers from "@/components/americano/SeedPlayers.vue";
 
 export default defineComponent({
     components: { SeedPlayers },
-    data: function() {
+    data: function () {
         return {
             maxScore: 24,
             maxScoreInvalid: false,
@@ -413,6 +443,16 @@ export default defineComponent({
 
             store.commit.americanoStore.SET_RULES(newRules);
         },
+        onTournamentChange() {
+            const name = this.tournamentNameRule as string;
+            const names = getTournamentNames();
+            if (names.includes(name)) {
+                store.commit.americanoStore.LOAD_STATE(name);
+            } else {
+                store.commit.americanoStore.SET_TOURNAMENT_NAME(name);
+                store.commit.americanoStore.RESET();
+            }
+        },
         isDuplicateName(id: number) {
             return this.$data.duplicateNameIds.includes(id);
         },
@@ -543,6 +583,17 @@ export default defineComponent({
         },
         numberOfCourts() {
             return Math.floor(this.amountOfPlayersRule / 4);
+        },
+        tournamentNames() {
+            return getTournamentNames();
+        },
+        tournamentNameRule: {
+            get() {
+                return store.getters.americanoStore.getTournamentName;
+            },
+            set(value: string) {
+                store.commit.americanoStore.SET_TOURNAMENT_NAME(value);
+            },
         },
     },
 });

--- a/src/services/storageService.ts
+++ b/src/services/storageService.ts
@@ -3,30 +3,68 @@ import { PadelGame } from "@/models/padelGame.interface";
 import { PadelPlayer } from "@/models/padelPlayer.interface";
 import { PadelRules } from "@/models/padelRules.interface";
 
-const _fullAmericanoState = "fullAmericanoState";
+const _tournaments = "fullAmericanoTournaments";
+const _currentTournament = "currentAmericanoTournament";
+
+function loadTournaments(): Record<string, FullAmericanoState> {
+    const loaded = localStorage.getItem(_tournaments);
+    return loaded ? JSON.parse(loaded) : {};
+}
+
+export function getTournamentNames(): string[] {
+    return Object.keys(loadTournaments());
+}
+
+export function getCurrentTournamentName(): string | null {
+    return localStorage.getItem(_currentTournament);
+}
+
+export function setCurrentTournamentName(name: string): void {
+    localStorage.setItem(_currentTournament, name);
+}
 
 export function saveAmericanoState(
     players: PadelPlayer[],
     games: PadelGame[],
     step: number,
     rules: PadelRules,
-    round: number
+    round: number,
+    name: string
 ): void {
-    const saveObject: FullAmericanoState = { players, games, step, rules, round };
+    const saveObject: FullAmericanoState = {
+        players,
+        games,
+        step,
+        rules,
+        round,
+    };
 
-    localStorage.setItem(_fullAmericanoState, JSON.stringify(saveObject));
+    const tournaments = loadTournaments();
+    tournaments[name] = saveObject;
+    localStorage.setItem(_tournaments, JSON.stringify(tournaments));
+    localStorage.setItem(_currentTournament, name);
 }
 
-export function loadAmericanoState(): FullAmericanoState | null {
-    const loadedState = localStorage.getItem(_fullAmericanoState);
+export function loadAmericanoState(name?: string): FullAmericanoState | null {
+    if (!name) {
+        name = localStorage.getItem(_currentTournament) || undefined;
+    }
 
-    if (loadedState === null) {
+    if (!name) {
         return null;
     }
 
-    return JSON.parse(loadedState);
+    const tournaments = loadTournaments();
+    return tournaments[name] || null;
 }
 
-export function removeAmericanoState(): void {
-    localStorage.removeItem(_fullAmericanoState);
+export function removeAmericanoState(name: string): void {
+    const tournaments = loadTournaments();
+    delete tournaments[name];
+    localStorage.setItem(_tournaments, JSON.stringify(tournaments));
+
+    const current = localStorage.getItem(_currentTournament);
+    if (current === name) {
+        localStorage.removeItem(_currentTournament);
+    }
 }


### PR DESCRIPTION
## Summary
- add datalist with available tournaments in setup
- load selected tournament or create a new one
- track currently selected tournament name in storage

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_688a3b7493148332bf51a82d7b0cbdde